### PR TITLE
Database clean-up during uninstall, 'Previously uploaded files' changed to 'All uploaded files'

### DIFF
--- a/modules/api_reference/config/install/field.storage.node.field_description.yml
+++ b/modules/api_reference/config/install/field.storage.node.field_description.yml
@@ -4,6 +4,10 @@ dependencies:
   module:
     - node
     - text
+    - devportal_api_reference
+  enforced:
+    module:
+      - devportal_api_reference
 id: node.field_description
 field_name: field_description
 entity_type: node

--- a/modules/api_reference/config/install/field.storage.node.field_project_id.yml
+++ b/modules/api_reference/config/install/field.storage.node.field_project_id.yml
@@ -3,6 +3,10 @@ status: true
 dependencies:
   module:
     - node
+    - devportal_api_reference
+  enforced:
+    module:
+      - devportal_api_reference
 id: node.field_project_id
 field_name: field_project_id
 entity_type: node

--- a/modules/api_reference/config/install/field.storage.node.field_source_file.yml
+++ b/modules/api_reference/config/install/field.storage.node.field_source_file.yml
@@ -4,6 +4,10 @@ dependencies:
   module:
     - file
     - node
+    - devportal_api_reference
+  enforced:
+    module:
+      - devportal_api_reference
 id: node.field_source_file
 field_name: field_source_file
 entity_type: node

--- a/modules/api_reference/config/install/field.storage.node.field_version.yml
+++ b/modules/api_reference/config/install/field.storage.node.field_version.yml
@@ -3,6 +3,10 @@ status: true
 dependencies:
   module:
     - node
+    - devportal_api_reference
+  enforced:
+    module:
+      - devportal_api_reference
 id: node.field_version
 field_name: field_version
 entity_type: node

--- a/modules/api_reference/devportal_api_reference.module
+++ b/modules/api_reference/devportal_api_reference.module
@@ -84,7 +84,7 @@ function devportal_api_reference_form_node_api_ref_swagger_20_edit_form_alter(&$
   $form['previous_files'] = [
     '#type' => 'details',
     '#weight' => -2,
-    '#title' => t('Previously uploaded files'),
+    '#title' => t('All uploaded files'),
     '#open' => TRUE,
   ];
   /** @var \Drupal\file\FileInterface $file */


### PR DESCRIPTION
Database clean-up during uninstall
'Previously uploaded files' changed to 'All uploaded files'