### PR TITLE
Fix fatal error when reference file is missing.

### DIFF
--- a/modules/api_reference/devportal_api_reference.services.yml
+++ b/modules/api_reference/devportal_api_reference.services.yml
@@ -12,3 +12,6 @@ services:
   plugin.manager.reference:
     class: Drupal\devportal_api_reference\ReferenceTypeManager
     parent: default_plugin_manager
+  logger.channel.api_reference:
+    parent: logger.channel_base
+    arguments: ['api_reference']

--- a/modules/api_reference/src/Plugin/Reference/OpenApi.php
+++ b/modules/api_reference/src/Plugin/Reference/OpenApi.php
@@ -3,15 +3,55 @@
 namespace Drupal\devportal_api_reference\Plugin\Reference;
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\devportal_api_reference\Plugin\OpenApiValidationException;
 use JsonSchema\Validator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
  * Base class for OpenAPI references.
  */
-abstract class OpenApi extends ReferenceBase {
+abstract class OpenApi extends ReferenceBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var \Drupal\Core\Cache\CacheBackendInterface $cache */
+    $cache = $container->get('cache.apifiles');
+    /** @var \Drupal\Core\Logger\LoggerChannelInterface $logger */
+    $logger = $container->get('logger.channel.api_reference');
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $cache,
+      $logger
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, CacheBackendInterface $cache, LoggerChannelInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->cache = $cache;
+    $this->logger = $logger;
+  }
 
   /**
    * {@inheritdoc}
@@ -74,9 +114,8 @@ abstract class OpenApi extends ReferenceBase {
    * {@inheritdoc}
    */
   public function parse(string $file_path): ?\stdClass {
-    $bin = \Drupal::cache('apifiles');
     $cid = $file_path . ':' . md5_file($file_path);
-    $cached = $bin->get($cid);
+    $cached = $this->cache->get($cid);
     if ($cached) {
       if (($cached->data['plugin'] ?? NULL) === $this->getPluginId()) {
         return $cached->data['object'] ?? NULL;
@@ -84,19 +123,25 @@ abstract class OpenApi extends ReferenceBase {
       return NULL;
     }
 
+    if (!file_exists($file_path)) {
+      $this->logger->warning("File doesn't exists: {$file_path}");
+      return NULL;
+    }
+
     $file_info = pathinfo($file_path);
     $file_ext = $file_info['extension'];
 
+    $input = file_get_contents($file_path);
     if (($file_ext === 'yaml') || ($file_ext === 'yml')) {
       try {
-        $openapi = Yaml::parse(file_get_contents($file_path), Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP);
+        $openapi = Yaml::parse($input, Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP);
       }
       catch (ParseException $e) {
         throw new \Exception("Can not parse YAML source file ({$file_path}). {$e->getMessage()}", 0, $e);
       }
     }
     elseif ($file_ext === 'json') {
-      $openapi = json_decode(file_get_contents($file_path), FALSE);
+      $openapi = json_decode($input, FALSE);
       if ($openapi === NULL) {
         throw new \Exception("The JSON source file ({$file_path}) cannot be decoded (possible syntax error) or the encoded data is deeper then the recursion limit (512).");
       }
@@ -111,7 +156,7 @@ abstract class OpenApi extends ReferenceBase {
 
     $this->validate($openapi);
 
-    $bin->set($cid, [
+    $this->cache->set($cid, [
       'object' => $openapi,
       'plugin' => $this->getPluginId(),
     ], Cache::PERMANENT);


### PR DESCRIPTION
When an api reference file goes missing from the file system (e.g.
moving the site between stages), then the validator failed, causing an
unhandled exception to break the site.

Also, the OpenApi abstract class is now properly dependency injected.