### PR TITLE
Fix filter.format.github_flavored_markdown not getting enabled on ins…

### DIFF
--- a/modules/api_reference/devportal_api_reference.install
+++ b/modules/api_reference/devportal_api_reference.install
@@ -11,6 +11,20 @@ use Drupal\filter\Entity\FilterFormat;
 const API_REFERENCE_FIELD_CHECK_ALLOW_REQUIRED = ['title'];
 
 /**
+ * Implements hook_install().
+ */
+function devportal_api_reference_install(): void {
+  // Enable the github_flavored_markdown filter format.
+  // FilterFormat::load() doesn't work if using config_installer!
+  $config = \Drupal::configFactory()
+    ->getEditable('filter.format.github_flavored_markdown');
+  $status = $config->get('status');
+  if ($status === FALSE) {
+    $config->set('status', TRUE)->save();
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function devportal_api_reference_uninstall() {

--- a/modules/api_reference/devportal_api_reference.module
+++ b/modules/api_reference/devportal_api_reference.module
@@ -27,19 +27,6 @@ function devportal_api_reference_bundles() {
 }
 
 /**
- * Implements hook_modules_installed().
- */
-function devportal_api_reference_modules_installed(array $modules) {
-  // The devportal module only provides the github_flavored_markdown filter
-  // format, devportal_api_reference enables it during install.
-  // Make sure that the devportal module has been installed, before trying to
-  // enable the filter format.
-  if (in_array('devportal', $modules)) {
-    FilterFormat::load('github_flavored_markdown')->enable()->save();
-  }
-}
-
-/**
  * Implements hook_menu_links_discovered_alter().
  */
 function devportal_api_reference_menu_links_discovered_alter(&$links) {


### PR DESCRIPTION
…tall

Commit 1cf4a8 tried to fix this issue once by moving the enabling from
hook_install() to hook_modules_installed(). This turned out to be only a
partial solution to the problem of
filter.format.github_flavored_markdown not getting enabled when using
config_installer to install a site. FilterForma::load() cannot be used
when installing with config_installer. Instead a direct config edit has
to be used. This can be done in hook_install(), without misusing
hook_modules_installed().