### PR TITLE
Remove redundant league/commonmark depdendency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "php": "^7.1",
         "knplabs/github-api": "^2.0",
         "php-http/guzzle6-adapter": "^v1.1",
-        "league/commonmark": "^0.15.3",
         "michelf/php-markdown": "^1.7.0",
         "erusev/parsedown": "^1.6.3",
         "justinrainbow/json-schema": "^5.2",


### PR DESCRIPTION
drupal/markdown already depends on it: https://git.drupalcode.org/project/markdown/blob/8.x-2.x/composer.json#L26

Also, this will ensure that when a new stable release gets available from `drupal/markdown` it updates the currently installed XSS vulnerable version of `league/commonmark` too.

https://www.drupal.org/project/markdown/issues/3024662
https://www.drupal.org/project/markdown/issues/3048976