### PR TITLE
Add code fixes to guides module

### DIFF
--- a/modules/guides/guides.routing.yml
+++ b/modules/guides/guides.routing.yml
@@ -7,8 +7,8 @@ guides.list:
     _permission: 'access guides'
 
 guides.guide:
-  path: '/admin/guides/{filename}'
+  path: '/admin/guides/{subdirectory}/{filename}'
   defaults:
     _controller: '\Drupal\guides\Controller\GuidesController::guideContent'
   requirements:
-    _permission: 'access guides'
+    _guides_access: 'TRUE'

--- a/modules/guides/guides.services.yml
+++ b/modules/guides/guides.services.yml
@@ -1,0 +1,16 @@
+services:
+  guides.guides_access_checker:
+    class: Drupal\guides\Access\GuidesAccessCheck
+    arguments: ['@guides.guides_storage']
+    tags:
+      - { name: access_check, applies_to: _guides_access }
+  guides.guides_storage:
+    class: Drupal\guides\GuidesStorage
+    arguments: ['@settings', '@cache.guides']
+    lazy: true
+  cache.guides:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin }
+    factory: cache_factory:get
+    arguments: [guides]

--- a/modules/guides/src/Access/GuidesAccessCheck.php
+++ b/modules/guides/src/Access/GuidesAccessCheck.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\guides\Access;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ *  USA.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\guides\GuidesStorageInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class GuidesAccessCheck.
+ */
+class GuidesAccessCheck implements AccessInterface {
+
+  /**
+   * The guides storage.
+   *
+   * @var \Drupal\guides\GuidesStorageInterface
+   */
+  protected $guidesStorage;
+
+  /**
+   * GuidesAccessCheck constructor.
+   *
+   * @param \Drupal\guides\GuidesStorageInterface $guides_storage
+   *   The guides storage.
+   */
+  public function __construct(GuidesStorageInterface $guides_storage) {
+    $this->guidesStorage = $guides_storage;
+  }
+
+  /**
+   * Grant access to the guides based on the existence of the files.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match interface.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface {
+    if ($account->hasPermission('access guides')) {
+      $file = $this->guidesStorage->getFile($route_match->getParameter('subdirectory'), $route_match->getParameter('filename'));
+
+      if ($file) {
+        return AccessResult::allowed();
+      }
+      // Return 404 instead of 403.
+      elseif (!$file) {
+        throw new NotFoundHttpException();
+      }
+
+    }
+    else {
+      return AccessResult::forbidden();
+    }
+  }
+
+}

--- a/modules/guides/src/Controller/GuidesController.php
+++ b/modules/guides/src/Controller/GuidesController.php
@@ -2,14 +2,29 @@
 
 namespace Drupal\guides\Controller;
 
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Link;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Site\Settings;
-use Drupal\Core\Url;
+use Drupal\guides\Exception\FileNotFoundException;
+use Drupal\guides\GuidesStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Parsedown;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * User guide page.
@@ -17,28 +32,28 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class GuidesController extends ControllerBase {
 
   /**
-   * The current route match.
+   * The guides storage.
    *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
+   * @var \Drupal\guides\GuidesStorageInterface
    */
-  protected $routeMatch;
+  protected $guidesStorage;
 
   /**
    * Creates a new HelpController.
    *
-   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
-   *   The current route match.
+   * @param \Drupal\guides\GuidesStorageInterface $guides_storage
+   *   The guides storage.
    */
-  public function __construct(RouteMatchInterface $route_match) {
-    $this->routeMatch = $route_match;
+  public function __construct(GuidesStorageInterface $guides_storage) {
+    $this->guidesStorage = $guides_storage;
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): self {
     return new static(
-      $container->get('current_route_match')
+      $container->get('guides.guides_storage')
     );
   }
 
@@ -48,35 +63,23 @@ class GuidesController extends ControllerBase {
    * @return array
    *   Render array.
    */
-  public function listGuides() {
-    $guides = [];
-    $guides_dir = DRUPAL_ROOT . (Settings::get('guides_dir') ?? '/guides');
+  public function listGuides(): array {
+    // Get the links of the files.
+    $guides = $this->guidesStorage->getLinks();
 
-    foreach (array_diff(scandir($guides_dir), ['..', '.']) as $guide_dir) {
-      $dir = $guides_dir . '/' . $guide_dir;
-      if (is_dir($dir)) {
-        foreach (glob($dir . '/*.md') as $md) {
-          if (file_exists($md)) {
-            $parts = pathinfo($md);
-            $link = Url::fromRoute('guides.guide', ['filename' => $parts['filename']]);
-            $link = Link::fromTextAndUrl(str_replace('_', ' ', $guide_dir), $link)->toString();
-            $guides[] = [
-              '#markup' => $link,
-            ];
-          }
-        }
-      }
-    }
-
+    // If the guides array isn't empty, return its content as item list.
     if (!empty($guides)) {
       return [
         '#theme' => 'item_list',
         '#items' => $guides,
       ];
     }
+    // Else return markup text.
     else {
       return [
-        '#markup' => $this->t('<strong>@text</strong>', ['@text' => 'No guides found.']),
+        '#type' => 'html_tag',
+        '#tag' => 'strong',
+        '#value' => $this->t('No guides found.'),
       ];
     }
   }
@@ -84,32 +87,26 @@ class GuidesController extends ControllerBase {
   /**
    * Page callback that renders a markdown file on the UI.
    *
+   * @param string $subdirectory
+   *   The name of the subdirectory which contains the guide file.
+   * @param string $filename
+   *   The name of the guide file.
+   *
    * @return array
    *   Render array.
+   *
+   * @throws \Drupal\guides\Exception\FileNotFoundException
+   *   Thrown when no guide file is found.
    */
-  public function guideContent($filename) {
-    $guides_dir = Settings::get('guides_dir') ?? '/guides';
-    $target = [
-      'dir' => FALSE,
-      'file' => FALSE,
-    ];
-
-    foreach (array_diff(scandir(DRUPAL_ROOT . $guides_dir), ['..', '.']) as $guide_dir) {
-      $dir = DRUPAL_ROOT . $guides_dir . '/' . $guide_dir;
-      $file = $dir . '/' . $filename . '.md';
-      if (file_exists($file)) {
-        $target['dir'] = $guides_dir . '/' . $guide_dir;
-        $target['file'] = $file;
-        break;
-      }
+  public function guideContent(string $subdirectory, string $filename): array {
+    try {
+      // Parses the guide file.
+      $md = new \Parsedown();
+      $md = $md->text($this->guidesStorage->getFileContent($subdirectory, $filename));
     }
-
-    if (!$target['file']) {
-      throw new NotFoundHttpException();
+    catch (FileNotFoundException $e) {
+      throw new FileNotFoundException($this->guidesStorage->getFile($subdirectory, $filename));
     }
-
-    $md = new Parsedown();
-    $md = $md->text(str_replace('@guide_path', $target['dir'], file_get_contents($target['file'])));
 
     return [
       '#markup' => $md,

--- a/modules/guides/src/Exception/FileNotFoundException.php
+++ b/modules/guides/src/Exception/FileNotFoundException.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+use Drupal\guides\GuidesInterface;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific FileNotFound exception.
+ */
+class FileNotFoundException extends RuntimeException {
+
+  /**
+   * The path of the file.
+   *
+   * @var string
+   */
+  protected $path;
+
+  public function __construct(string $path, string $message = 'File not found: @path.', int $code = 0, \Throwable $previous = null) {
+    $message = strtr($message, ['@path' => $path]);
+    $this->path = $path;
+    parent::__construct($message, $code, $previous);
+  }
+
+  /**
+   * The path of the file.
+   *
+   * @return string
+   *   The path of the file.
+   */
+  public function getPath() {
+    return $this->path;
+  }
+
+}

--- a/modules/guides/src/Exception/GuidesExceptionInterface.php
+++ b/modules/guides/src/Exception/GuidesExceptionInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific base exception.
+ */
+interface GuidesExceptionInterface extends \Throwable {
+
+}

--- a/modules/guides/src/Exception/ParseException.php
+++ b/modules/guides/src/Exception/ParseException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Thrown if the input file could not be parsed.
+ */
+class ParseException extends RuntimeException {
+
+}

--- a/modules/guides/src/Exception/RuntimeException.php
+++ b/modules/guides/src/Exception/RuntimeException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific Runtime exception.
+ */
+class RuntimeException extends \RuntimeException implements GuidesExceptionInterface {
+
+}

--- a/modules/guides/src/GuidesStorage.php
+++ b/modules/guides/src/GuidesStorage.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\guides;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Site\Settings;
+use Drupal\guides\Exception\FileNotFoundException;
+
+/**
+ * Defines GuidesStorage for Guides files, links and directories.
+ */
+final class GuidesStorage implements GuidesStorageInterface {
+
+  /**
+   * The settings of the site.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * The cache backend service.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
+  /**
+   * GuidesStorage constructor.
+   *
+   * @param \Drupal\Core\Site\Settings $settings
+   *   The settings of the site.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   */
+  public function __construct(Settings $settings, CacheBackendInterface $cache_backend) {
+    $this->settings = $settings;
+    $this->cacheBackend = $cache_backend;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  private function getDirectory(): string {
+    return DRUPAL_ROOT . ($this->settings->get('guides_dir') ?? '/guides');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFiles(): array {
+    $directory = $this->getDirectory();
+    $cid = 'guides_files:' . $directory;
+    $data_cached = $this->cacheBackend->get($cid);
+
+    if ($data_cached) {
+      $guides = $data_cached->data;
+    }
+    else {
+      $iterator = new \RecursiveDirectoryIterator($directory, \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS);
+      $filter = new \RecursiveCallbackFilterIterator($iterator, function ($current, $key, $iterator) {
+        if ($iterator->hasChildren()) {
+          return TRUE;
+        }
+        $path = $current->getPathname();
+        if (is_file($path)) {
+          return substr($current->getFilename(), -3) == '.md';
+        }
+
+        return FALSE;
+      });
+
+      $guides = [];
+      $files = new \RecursiveIteratorIterator($filter);
+      foreach ($files as $md) {
+        if ($files->getDepth() == 1) {
+          $guides[] = $md->getPathname();
+        }
+      }
+
+      $this->cacheBackend->set($cid, $guides);
+    }
+
+    return $guides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFile(string $subdirectory, string $file_name): string {
+    $file_path = $this->getDirectory() . '/' . $subdirectory . '/' . $file_name . '.md';
+
+    if (file_exists($file_path) && in_array($file_path, $this->getFiles())) {
+      return $file_path;
+    }
+    else {
+      throw new FileNotFoundException($file_path);
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFileContent(string $subdirectory, string $file_name): string {
+    $file_path = $this->getFile($subdirectory, $file_name);
+    if (file_exists($file_path)) {
+      $guide_directory = dirname($file_path);
+      $content = str_replace('@guide_path', $guide_directory, file_get_contents($file_path));
+      return $content;
+    }
+    else {
+      throw new FileNotFoundException($file_path);
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLinks(): array {
+    $guides_files = $this->getFiles();
+    $guides = [];
+
+    foreach ($guides_files as $md) {
+      if (file_exists($md)) {
+        $parts = pathinfo($md);
+        $guides[] = Link::createFromRoute(str_replace('_', ' ', basename($parts['dirname'])), 'guides.guide', ['subdirectory' => basename($parts['dirname']), 'filename' => $parts['filename']])->toRenderable();
+      }
+    }
+
+    return $guides;
+  }
+
+}

--- a/modules/guides/src/GuidesStorageInterface.php
+++ b/modules/guides/src/GuidesStorageInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\guides;
+
+use Drupal\guides\Exception\FileNotFoundException;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Defines an interface for guides storage classes.
+ */
+interface GuidesStorageInterface {
+
+  /**
+   * Gets the path of the guides files which are in the guides subdirectories.
+   *
+   * @return array
+   *   The array of the paths of the guides files.
+   */
+  public function getFiles(): array;
+
+  /**
+   * Get the path of the given file name in the given subdirectory.
+   *
+   * @param string $subdirectory
+   *   The guides subdirectory.
+   * @param string $file_name
+   *   The path of the file.
+   *
+   * @return string
+   *   The path of the given file name in the given subdirectory.
+   *
+   * @throws \Drupal\guides\Exception\FileNotFoundException
+   *   Thrown if the file with the given name and subdirectory is not found.
+   */
+  public function getFile(string $subdirectory, string $file_name): string;
+
+  /**
+   * Gets the content of the given file.
+   *
+   * Parses a markdown file or throws an exception if the file doesn't exist or
+   * can't be parsed.
+   *
+   * @param string $subdirectory
+   *   The guides subdirectory.
+   * @param string $file_name
+   *   The path of the file.
+   *
+   * @return string
+   *   The content of the file or an exception.
+   *
+   * @throws \Drupal\guides\Exception\FileNotFoundException
+   *   Thrown if the file with the given name and subdirectory is not found.
+   */
+  public function getFileContent(string $subdirectory, string $file_name): string;
+
+  /**
+   * Gets the links of the guides files.
+   *
+   * @return array
+   *   The array of the links of the files.
+   */
+  public function getLinks(): array;
+
+}

--- a/modules/guides/src/ProxyClass/GuidesStorage.php
+++ b/modules/guides/src/ProxyClass/GuidesStorage.php
@@ -1,0 +1,104 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\guides\GuidesStorage' "modules/contrib/devportal/modules/guides/src".
+ */
+
+namespace Drupal\guides\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\guides\GuidesStorage.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class GuidesStorage implements \Drupal\guides\GuidesStorageInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\guides\GuidesStorage
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFiles(): array
+        {
+            return $this->lazyLoadItself()->getFiles();
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFile(string $subdirectory, string $file_name): string
+        {
+            return $this->lazyLoadItself()->getFile($subdirectory, $file_name);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFileContent(string $subdirectory, string $file_name): string
+        {
+            return $this->lazyLoadItself()->getFileContent($subdirectory, $file_name);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getLinks(): array
+        {
+            return $this->lazyLoadItself()->getLinks();
+        }
+
+    }
+
+}


### PR DESCRIPTION
Route access control checking added to check whether the requested
file exists or not.
Module specific exception handling added if Parsedown() can't
parse the file.
Service created for getting the list of the guide directories.
Unused current route match deleted from GuidesController.
Add dependency injection to get 'settings' service instead of
statically use it.