### PR TITLE
Add code fixes to guides module

### DIFF
--- a/modules/guides/guides.routing.yml
+++ b/modules/guides/guides.routing.yml
@@ -7,8 +7,8 @@ guides.list:
     _permission: 'access guides'
 
 guides.guide:
-  path: '/admin/guides/{filename}'
+  path: '/admin/guides/{path}'
   defaults:
     _controller: '\Drupal\guides\Controller\GuidesController::guideContent'
   requirements:
-    _permission: 'access guides'
+    _guides_access: 'TRUE'

--- a/modules/guides/guides.services.yml
+++ b/modules/guides/guides.services.yml
@@ -1,0 +1,16 @@
+services:
+  guides.guides_access_checker:
+    class: Drupal\guides\Access\GuidesAccessCheck
+    arguments: ['@guides.guides_storage']
+    tags:
+      - { name: access_check, applies_to: _guides_access }
+  guides.guides_storage:
+    class: Drupal\guides\GuidesStorage
+    arguments: ['@settings', '@cache.guides']
+    lazy: true
+  cache.guides:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin }
+    factory: cache_factory:get
+    arguments: [guides]

--- a/modules/guides/src/Access/GuidesAccessCheck.php
+++ b/modules/guides/src/Access/GuidesAccessCheck.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\guides\Access;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ *  USA.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\guides\GuidesStorageInterface;
+use Drupal\guides\GuidesStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class GuidesAccessCheck.
+ */
+class GuidesAccessCheck implements AccessInterface {
+
+  /**
+   * The guides storage.
+   *
+   * @var \Drupal\guides\GuidesStorageInterface
+   */
+  protected $guidesStorage;
+
+  /**
+   * GuidesAccessCheck constructor.
+   *
+   * @param \Drupal\guides\GuidesStorageInterface $guides_storage
+   *   The guides storage.
+   */
+  public function __construct(GuidesStorageInterface $guides_storage) {
+    $this->guidesStorage = $guides_storage;
+  }
+
+  /**
+   * Grant access to the guides based on the existence of the files.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match interface.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface {
+    if ($account->hasPermission('access guides')) {
+      $file = $this->guidesStorage->getFilePath(str_replace(guidesStorage::GUIDES_SEPARATOR, '/', $route_match->getParameter('path')));
+
+      if ($file) {
+        return AccessResult::allowed();
+      }
+      // Return 404 instead of 403.
+      else {
+        throw new NotFoundHttpException();
+      }
+
+    }
+    else {
+      return AccessResult::forbidden();
+    }
+  }
+
+}

--- a/modules/guides/src/Exception/FileNotFoundException.php
+++ b/modules/guides/src/Exception/FileNotFoundException.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+use Throwable;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific FileNotFound exception.
+ */
+class FileNotFoundException extends RuntimeException {
+
+  /**
+   * The path of the file.
+   *
+   * @var string
+   */
+  protected $path;
+
+  /**
+   * FileNotFoundException constructor.
+   *
+   * @param string $path
+   *   The path of the file.
+   * @param \Throwable|null $previous
+   *   Previous exception.
+   */
+  public function __construct(string $path, \Throwable $previous = NULL) {
+    $this->path = $path;
+    parent::__construct('File not found:' . $path, 0, $previous);
+  }
+
+  /**
+   * The path of the file.
+   *
+   * @return string
+   *   The path of the file.
+   */
+  public function getPath() {
+    return $this->path;
+  }
+
+}

--- a/modules/guides/src/Exception/GuidesExceptionInterface.php
+++ b/modules/guides/src/Exception/GuidesExceptionInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific base exception.
+ */
+interface GuidesExceptionInterface extends \Throwable {
+
+}

--- a/modules/guides/src/Exception/RuntimeException.php
+++ b/modules/guides/src/Exception/RuntimeException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\guides\Exception;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Module specific Runtime exception.
+ */
+class RuntimeException extends \RuntimeException implements GuidesExceptionInterface {
+
+}

--- a/modules/guides/src/GuidesStorage.php
+++ b/modules/guides/src/GuidesStorage.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\guides;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Site\Settings;
+use Drupal\guides\Exception\FileNotFoundException;
+
+/**
+ * Defines GuidesStorage for Guides files, links and directories.
+ */
+final class GuidesStorage implements GuidesStorageInterface {
+
+  /**
+   * Provides a separator between guides subdirectory and guide file.
+   *
+   * The temporarily used separator to separate the guides subdirectory and the
+   * guide file, until the core bug will be fixed:
+   * https://www.drupal.org/project/drupal/issues/2741939.
+   */
+  const GUIDES_SEPARATOR = '___';
+
+  /**
+   * The settings of the site.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * The cache backend service.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
+  /**
+   * GuidesStorage constructor.
+   *
+   * @param \Drupal\Core\Site\Settings $settings
+   *   The settings of the site.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   */
+  public function __construct(Settings $settings, CacheBackendInterface $cache_backend) {
+    $this->settings = $settings;
+    $this->cacheBackend = $cache_backend;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  private function getDirectory(): string {
+    return DRUPAL_ROOT . ($this->settings->get('guides_dir') ?? '/guides');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilePaths(): array {
+    $directory = $this->getDirectory();
+    $cid = 'guides_files:' . $directory;
+    $data_cached = $this->cacheBackend->get($cid);
+
+    if ($data_cached) {
+      $guides = $data_cached->data;
+    }
+    else {
+      $iterator = new \RecursiveDirectoryIterator($directory, \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS);
+      $filter = new \RecursiveCallbackFilterIterator($iterator, static function (\SplFileInfo $current, string $key, \RecursiveIterator $iterator): bool {
+        if ($iterator->hasChildren()) {
+          return TRUE;
+        }
+        $path = $current->getPathname();
+        if (is_file($path)) {
+          return $current->getExtension() === 'md';
+        }
+
+        return FALSE;
+      });
+
+      $guides = [];
+      $files = new \RecursiveIteratorIterator($filter);
+      foreach ($files as $md) {
+        if ($files->getDepth() === 1) {
+          $guides[] = $md->getPathname();
+        }
+      }
+
+      $this->cacheBackend->set($cid, $guides);
+    }
+
+    return $guides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilePath(string $path): string {
+    $file_path = $this->getDirectory() . DIRECTORY_SEPARATOR . str_replace(self::GUIDES_SEPARATOR, '/', $path) . '.md';
+
+    if (in_array($file_path, $this->getFilePaths()) && file_exists($file_path)) {
+      return $file_path;
+    }
+    else {
+      // If the file does not exist, then the cache contains invalid data, so it
+      // has to be rebuilt.
+      $this->cacheBackend->deleteAll();
+      throw new FileNotFoundException($file_path);
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFileContent(string $path): string {
+    $file_path = $this->getFilePath(str_replace(self::GUIDES_SEPARATOR, '/', $path));
+    return str_replace('@guide_path', dirname($file_path), file_get_contents($file_path));
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLinks(): array {
+    $guides_files = $this->getFilePaths();
+    $guides = [];
+
+    foreach ($guides_files as $md) {
+      $parts = pathinfo($md);
+      $guides[] = Link::createFromRoute(str_replace('_', ' ', basename($parts['dirname'])), 'guides.guide', ['path' => (basename($parts['dirname']) . self::GUIDES_SEPARATOR . $parts['filename'])])->toRenderable();
+    }
+
+    return $guides;
+  }
+
+}

--- a/modules/guides/src/GuidesStorageInterface.php
+++ b/modules/guides/src/GuidesStorageInterface.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\guides;
+
+use Drupal\guides\Exception\FileNotFoundException;
+
+/**
+ * Copyright (C) 2019 PRONOVIX GROUP BVBA.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+/**
+ * Defines an interface for guides storage classes.
+ */
+interface GuidesStorageInterface {
+
+  /**
+   * Gets the path of the guides files which are in the guides subdirectories.
+   *
+   * The returned list of files may contain paths of files that does not
+   * actually exist in the filesystem.
+   *
+   * @return array
+   *   The array of the paths of the guides files.
+   */
+  public function getFilePaths(): array;
+
+  /**
+   * Get the path of the given file name in the given subdirectory.
+   *
+   * @param string $path
+   *   The relative path of the guides file without extension.
+   *
+   * @return string
+   *   The path of the given file name in the given subdirectory.
+   *
+   * @throws \Drupal\guides\Exception\FileNotFoundException
+   *   Thrown if the file with the given name and subdirectory is not found.
+   */
+  public function getFilePath(string $path): string;
+
+  /**
+   * Gets the content of the given file.
+   *
+   * Parses a markdown file or throws an exception if the file doesn't exist or
+   * can't be parsed.
+   *
+   * @param string $path
+   *   The relative path of the guides file without extension.
+   *
+   * @return string
+   *   The content of the file or an exception.
+   *
+   * @throws \Drupal\guides\Exception\FileNotFoundException
+   *   Thrown if the file with the given name and subdirectory is not found.
+   */
+  public function getFileContent(string $path): string;
+
+  /**
+   * Gets the links of the guides files.
+   *
+   * This method intentionally does not validate whether a file still exists or
+   * not, but the getFilePath() method validates it and because it is called by the
+   * route access handler, therefore the
+   * http://example.com/guides/file_does_not_exists_anymore page will return
+   * a 404.
+   *
+   * @return array
+   *   The array of the links of the files.
+   */
+  public function getLinks(): array;
+
+}

--- a/modules/guides/src/ProxyClass/GuidesStorage.php
+++ b/modules/guides/src/ProxyClass/GuidesStorage.php
@@ -1,0 +1,104 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\guides\GuidesStorage' "modules/contrib/devportal/modules/guides/src".
+ */
+
+namespace Drupal\guides\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\guides\GuidesStorage.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class GuidesStorage implements \Drupal\guides\GuidesStorageInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\guides\GuidesStorage
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFilePaths(): array
+        {
+            return $this->lazyLoadItself()->getFilePaths();
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFilePath(string $path): string
+        {
+            return $this->lazyLoadItself()->getFilePath($path);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getFileContent(string $path): string
+        {
+            return $this->lazyLoadItself()->getFileContent($path);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getLinks(): array
+        {
+            return $this->lazyLoadItself()->getLinks();
+        }
+
+    }
+
+}


### PR DESCRIPTION
Route access control checking added to check if the current
user has 'access guides' permission and whether the requested
file exists or not.
Module specific exception handling added if Parsedown() can't
parse the file.
Service created for getting the list of the guide directories.
Unused current route match deleted from GuidesController.